### PR TITLE
update skipper flags

### DIFF
--- a/kube-ingress-aws-controller/templates/daemonset.yaml
+++ b/kube-ingress-aws-controller/templates/daemonset.yaml
@@ -57,8 +57,11 @@ spec:
           - "-metrics-exp-decay-sample"
           - "-kubernetes-https-redirect=true"
           - "-application-log-level={{ .Values.skipper.logLevel }}"
+          - "-lb-healthcheck-interval=3s"
+          - "-enable-connection-metrics"
+          - "-reverse-source-predicate"
 {{ if .Values.prometheusOperator.enable }}
-          - "-enable-prometheus-metrics"
+          - "-metrics-flavour=prometheus"
 {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}


### PR DESCRIPTION
Enable prometheus with the newer flag, which will not be deprecated:

          - "-metrics-flavour=prometheus"

Set loadbalancer active healthchecks for failing backends to 3s interval:

          - "-lb-healthcheck-interval=3s"

Enable loadbalancer connection (new, active, ..) metrics

          - "-enable-connection-metrics"

Make AWS X-Forwarded-For header parsing the right way for the automatically add health check endpoint for example: 

          - "-reverse-source-predicate"